### PR TITLE
[log]: GHC_OSD Added logging to LineageController

### DIFF
--- a/api/conf/logback.xml
+++ b/api/conf/logback.xml
@@ -3,7 +3,7 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>${application.home:-.}/logs/application.log</file>
         <encoder>
-            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+            <pattern>%d{yy/MM/dd HH:mm:ss}; thread=%thread; level=%p; %marker; class=%c; method=%method; lineNumber=%L; msg=%message%n%xException</pattern>
         </encoder>
     </appender>
     <appender name="FILE" class="ch.qos.logback.core.ConsoleAppenderr">
@@ -27,7 +27,7 @@
     <logger name="application" level="INFO" />
     <logger name="slick.jdbc.JdbcBackend.statement"  level="INFO" />
     <logger name="logger.org.jdbcdslog.StatementLogger"  level="INFO" />
-    <logger name="akka" level="DEBUG" />
+    <logger name="akka" level="INFO" />
     <root level="INFO">
         <appender-ref ref="ASYNCFILE" />
         <appender-ref ref="ASYNCSTDOUT" />


### PR DESCRIPTION
Link to Issue: https://github.com/intuit/superglue/issues/24

Tested by hitting:
http://localhost:8080/api/v1/lineage/table/LOREM?bw=-1&fw=-1

Error Stack Received - Refer --> logs/application.log
```
20/10/01 22:27:15; thread=application-akka.actor.default-dispatcher-4; level=INFO; ; class=akka.event.slf4j.Slf4jLogger; method=?; lineNumber=?; msg=Slf4jLogger started
20/10/01 22:27:16; thread=play-dev-mode-akka.actor.default-dispatcher-7; level=INFO; ; class=play.api.http.EnabledFilters; method=?; lineNumber=?; msg=Enabled Filters (see <https://www.playframework.com/documentation/latest/Filters>):

    play.filters.csrf.CSRFFilter
    play.filters.headers.SecurityHeadersFilter
    play.filters.hosts.AllowedHostsFilter
    play.filters.cors.CORSFilter

20/10/01 22:27:16; thread=play-dev-mode-akka.actor.default-dispatcher-7; level=INFO; ; class=play.api.Play; method=?; lineNumber=?; msg=Application started (Dev)
20/10/01 22:27:16; thread=application-akka.actor.default-dispatcher-4; level=ERROR; id=1; class=v1.lineage.LineageController; method=?; lineNumber=?; msg=Unexpected error constructing lineage for table "LOREM"
java.lang.Exception: Backward depth cannot be negative
	at com.intuit.superglue.lineage.LineageService.tableLineage(LineageService.scala:31)
	at v1.lineage.LineageController.lookupTableLineage$1(LineageController.scala:69)
	at v1.lineage.LineageController.handleRequest$1(LineageController.scala:101)
	at v1.lineage.LineageController.$anonfun$table$1(LineageController.scala:118)
	at v1.lineage.LineageActionBuilder.invokeBlock(LineageActionBuilder.scala:58)
	at v1.lineage.LineageActionBuilder.invokeBlock(LineageActionBuilder.scala:38)
	at play.api.mvc.ActionBuilder$$anon$10.apply(Action.scala:419)
	at play.api.mvc.Action.$anonfun$apply$2(Action.scala:96)
	at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:91)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:91)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:44)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)

```