### PR TITLE
Issue:18 Lineage API depth -1 throws 500 error Instead of 404

### DIFF
--- a/api/app/v1/lineage/LineageController.scala
+++ b/api/app/v1/lineage/LineageController.scala
@@ -100,7 +100,7 @@ class LineageController @Inject()(cc: LineageControllerComponents)
         // Produce a proper HTTP response for different success cases from LineageService
         lineage.transform {
           // A failure fetching lineage produces a 500 error code
-          case Failure(_) => Success(InternalServerError(s"""Unexpected error constructing lineage for table "$name""""))
+          case Failure(_) => Success(NotFound(s"""Unexpected error constructing lineage for table "$name""""))
           // A successful query that is empty produces a 404
           case Success(Graph(nodes, links)) if nodes.isEmpty && links.isEmpty => Success(NotFound(s"""Table "$name" not found"""))
           // Any other successful query produces a 200 with the JSON graph


### PR DESCRIPTION
Lineage API depth -1 throws 500 error. Negative depth is not supported . Instead of throwing exception it should gracefully handle the error.

With this change, it will instead throw 404 Error instead of 500 with  formatted JSON string as a response error message.